### PR TITLE
REGULA_R00001 

### DIFF
--- a/rules/admin_policy.rego
+++ b/rules/admin_policy.rego
@@ -7,6 +7,7 @@ resource_type = "MULTIPLE"
 # IAM policies should not have full "*:*" administrative privileges. IAM policies should start with a minimum set of permissions and include more as needed rather than starting with full administrative privileges. Providing full administrative privileges when unnecessary exposes resources to potentially unwanted actions.
 #
 # CIS_1-22
+# REGULA_R00002
 #
 # aws_iam_group_policy
 # aws_iam_policy

--- a/rules/user_attached_policy.rego
+++ b/rules/user_attached_policy.rego
@@ -1,0 +1,46 @@
+package rules.user_attached_policy
+
+import data.fugue
+
+resource_type = "MULTIPLE"
+
+# IAM policies should not be attached to users. Assigning privileges at the group or role level reduces the complexity of access management as the number of users grow. Reducing access management complexity may reduce opportunity for a principal to inadvertently receive or retain excessive privileges.
+#
+# CIS_1-16
+# REGULA_R00001
+#
+# aws_iam_policy_attachment
+# aws_iam_user_policy
+# aws_iam_user_policy_attachment
+
+user_policies = fugue.resources("aws_iam_user_policy")
+user_policy_attachments = fugue.resources("aws_iam_user_policy_attachment")
+policy_attachments = fugue.resources("aws_iam_policy_attachment")
+
+all_policy_resources[name] = p {
+  p = user_policies[name]
+} {
+  p = user_policy_attachments[name]
+} {
+  p = policy_attachments[name]
+}
+
+is_invalid(resource) {
+  resource = user_policies[name]
+} {
+  resource = user_policy_attachments[name]
+} {
+  resource = policy_attachments[name]
+  resource.users != null
+  resource.users != [""]
+}
+
+policy[p] {
+  resource = all_policy_resources[name]
+  is_invalid(resource)
+  p = fugue.deny_resource(resource)
+} {
+  resource = all_policy_resources[name]
+  not is_invalid(resource)
+  p = fugue.allow_resource(resource)
+}

--- a/tests/rules/inputs/user_attached_policy.rego
+++ b/tests/rules/inputs/user_attached_policy.rego
@@ -1,0 +1,1557 @@
+# This package was automatically generated from:
+#
+#     tests/rules/inputs/user_attached_policy.tf
+#
+# using `generate_test_inputs.sh` and should not be modified
+# directly.
+package tests.rules.user_attached_policy
+mock_input = {
+  "format_version": "0.1",
+  "terraform_version": "0.12.15",
+  "planned_values": {
+    "root_module": {
+      "resources": [
+        {
+          "address": "aws_iam_group.valid_group_blank_users",
+          "mode": "managed",
+          "type": "aws_iam_group",
+          "name": "valid_group_blank_users",
+          "provider_name": "aws",
+          "schema_version": 0,
+          "values": {
+            "name": "valid_group_blank_users",
+            "path": "/"
+          }
+        },
+        {
+          "address": "aws_iam_group.valid_group_empty_list_users",
+          "mode": "managed",
+          "type": "aws_iam_group",
+          "name": "valid_group_empty_list_users",
+          "provider_name": "aws",
+          "schema_version": 0,
+          "values": {
+            "name": "valid_group_empty_list_users",
+            "path": "/"
+          }
+        },
+        {
+          "address": "aws_iam_group.valid_group_missing_users",
+          "mode": "managed",
+          "type": "aws_iam_group",
+          "name": "valid_group_missing_users",
+          "provider_name": "aws",
+          "schema_version": 0,
+          "values": {
+            "name": "valid_group_missing_users",
+            "path": "/"
+          }
+        },
+        {
+          "address": "aws_iam_group_membership.valid_group_blank_users_membership",
+          "mode": "managed",
+          "type": "aws_iam_group_membership",
+          "name": "valid_group_blank_users_membership",
+          "provider_name": "aws",
+          "schema_version": 0,
+          "values": {
+            "group": "valid_group_blank_users",
+            "name": "valid_group_blank_users_membership",
+            "users": [
+              "valid_group_blank_user"
+            ]
+          }
+        },
+        {
+          "address": "aws_iam_group_membership.valid_group_empty_list_users_membership",
+          "mode": "managed",
+          "type": "aws_iam_group_membership",
+          "name": "valid_group_empty_list_users_membership",
+          "provider_name": "aws",
+          "schema_version": 0,
+          "values": {
+            "group": "valid_group_empty_list_users",
+            "name": "valid_group_empty_list_users_membership",
+            "users": [
+              "valid_group_empty_list_user"
+            ]
+          }
+        },
+        {
+          "address": "aws_iam_group_membership.valid_group_missing_users_membership",
+          "mode": "managed",
+          "type": "aws_iam_group_membership",
+          "name": "valid_group_missing_users_membership",
+          "provider_name": "aws",
+          "schema_version": 0,
+          "values": {
+            "group": "valid_group_missing_users",
+            "name": "valid_group_missing_users_membership",
+            "users": [
+              "valid_group_missing_user"
+            ]
+          }
+        },
+        {
+          "address": "aws_iam_policy.invalid_normal_policy",
+          "mode": "managed",
+          "type": "aws_iam_policy",
+          "name": "invalid_normal_policy",
+          "provider_name": "aws",
+          "schema_version": 0,
+          "values": {
+            "description": "Invalid normal policy attached to user",
+            "name": "invalid_normal_policy",
+            "name_prefix": null,
+            "path": "/",
+            "policy": "{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Action\": [\n        \"*\"\n      ],\n      \"Effect\": \"Deny\",\n      \"Resource\": \"*\"\n    }\n  ]\n}\n"
+          }
+        },
+        {
+          "address": "aws_iam_policy.invalid_user_policy_attachment_policy",
+          "mode": "managed",
+          "type": "aws_iam_policy",
+          "name": "invalid_user_policy_attachment_policy",
+          "provider_name": "aws",
+          "schema_version": 0,
+          "values": {
+            "description": "Invalid user policy attachment policy",
+            "name": "invalid_user_policy_attachment_policy",
+            "name_prefix": null,
+            "path": "/",
+            "policy": "{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Action\": [\n        \"ec2:Describe*\"\n      ],\n      \"Effect\": \"Allow\",\n      \"Resource\": \"*\"\n    }\n  ]\n}\n"
+          }
+        },
+        {
+          "address": "aws_iam_policy.valid_group_blank_users_policy",
+          "mode": "managed",
+          "type": "aws_iam_policy",
+          "name": "valid_group_blank_users_policy",
+          "provider_name": "aws",
+          "schema_version": 0,
+          "values": {
+            "description": "Valid group blank users policy",
+            "name": "valid_group_blank_users_policy",
+            "name_prefix": null,
+            "path": "/",
+            "policy": "{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Action\": [\n        \"ec2:Describe*\"\n      ],\n      \"Effect\": \"Deny\",\n      \"Resource\": \"*\"\n    }\n  ]\n}\n"
+          }
+        },
+        {
+          "address": "aws_iam_policy.valid_group_empty_list_users_policy",
+          "mode": "managed",
+          "type": "aws_iam_policy",
+          "name": "valid_group_empty_list_users_policy",
+          "provider_name": "aws",
+          "schema_version": 0,
+          "values": {
+            "description": "Valid group empty list users policy",
+            "name": "valid_group_empty_list_users_policy",
+            "name_prefix": null,
+            "path": "/",
+            "policy": "{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Action\": [\n        \"ec2:Describe*\"\n      ],\n      \"Effect\": \"Deny\",\n      \"Resource\": \"*\"\n    }\n  ]\n}\n"
+          }
+        },
+        {
+          "address": "aws_iam_policy.valid_group_missing_users_policy",
+          "mode": "managed",
+          "type": "aws_iam_policy",
+          "name": "valid_group_missing_users_policy",
+          "provider_name": "aws",
+          "schema_version": 0,
+          "values": {
+            "description": "Valid group missing users policy",
+            "name": "valid_group_missing_users_policy",
+            "name_prefix": null,
+            "path": "/",
+            "policy": "{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Action\": [\n        \"ec2:Describe*\"\n      ],\n      \"Effect\": \"Deny\",\n      \"Resource\": \"*\"\n    }\n  ]\n}\n"
+          }
+        },
+        {
+          "address": "aws_iam_policy.valid_role_policy",
+          "mode": "managed",
+          "type": "aws_iam_policy",
+          "name": "valid_role_policy",
+          "provider_name": "aws",
+          "schema_version": 0,
+          "values": {
+            "description": "Valid role policy",
+            "name": "valid_role_policy",
+            "name_prefix": null,
+            "path": "/",
+            "policy": "{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Action\": [\n        \"ec2:Describe*\"\n      ],\n      \"Effect\": \"Allow\",\n      \"Resource\": \"*\"\n    }\n  ]\n}\n"
+          }
+        },
+        {
+          "address": "aws_iam_policy_attachment.invalid_normal_policy_attachment",
+          "mode": "managed",
+          "type": "aws_iam_policy_attachment",
+          "name": "invalid_normal_policy_attachment",
+          "provider_name": "aws",
+          "schema_version": 0,
+          "values": {
+            "groups": null,
+            "name": "invalid_normal_policy_attachment",
+            "roles": null,
+            "users": [
+              "invalid_normal_policy_user"
+            ]
+          }
+        },
+        {
+          "address": "aws_iam_policy_attachment.valid_group_policy_attachment_blank_users",
+          "mode": "managed",
+          "type": "aws_iam_policy_attachment",
+          "name": "valid_group_policy_attachment_blank_users",
+          "provider_name": "aws",
+          "schema_version": 0,
+          "values": {
+            "groups": [
+              "valid_group_blank_users"
+            ],
+            "name": "valid_group_policy_attachment_blank_users",
+            "roles": null,
+            "users": [
+              ""
+            ]
+          }
+        },
+        {
+          "address": "aws_iam_policy_attachment.valid_group_policy_attachment_empty_list_users",
+          "mode": "managed",
+          "type": "aws_iam_policy_attachment",
+          "name": "valid_group_policy_attachment_empty_list_users",
+          "provider_name": "aws",
+          "schema_version": 0,
+          "values": {
+            "groups": [
+              "valid_group_empty_list_users"
+            ],
+            "name": "valid_group_policy_attachment_empty_list_users",
+            "roles": null,
+            "users": null
+          }
+        },
+        {
+          "address": "aws_iam_policy_attachment.valid_group_policy_attachment_missing_users",
+          "mode": "managed",
+          "type": "aws_iam_policy_attachment",
+          "name": "valid_group_policy_attachment_missing_users",
+          "provider_name": "aws",
+          "schema_version": 0,
+          "values": {
+            "groups": [
+              "valid_group_missing_users"
+            ],
+            "name": "valid_group_policy_attachment_missing_users",
+            "roles": null,
+            "users": null
+          }
+        },
+        {
+          "address": "aws_iam_policy_attachment.valid_role_policy_attachment",
+          "mode": "managed",
+          "type": "aws_iam_policy_attachment",
+          "name": "valid_role_policy_attachment",
+          "provider_name": "aws",
+          "schema_version": 0,
+          "values": {
+            "groups": null,
+            "name": "valid_role_policy_attachment",
+            "roles": [
+              "valid_role"
+            ],
+            "users": null
+          }
+        },
+        {
+          "address": "aws_iam_role.valid_role",
+          "mode": "managed",
+          "type": "aws_iam_role",
+          "name": "valid_role",
+          "provider_name": "aws",
+          "schema_version": 0,
+          "values": {
+            "assume_role_policy": "{\n\"Version\": \"2012-10-17\",\n\"Statement\": [\n  {\n    \"Action\": \"sts:AssumeRole\",\n    \"Principal\": {\n      \"Service\": \"ec2.amazonaws.com\"\n    },\n    \"Effect\": \"Allow\",\n    \"Sid\": \"\"\n  }\n ]\n}\n",
+            "description": null,
+            "force_detach_policies": false,
+            "max_session_duration": 3600,
+            "name": "valid_role",
+            "name_prefix": null,
+            "path": "/",
+            "permissions_boundary": null,
+            "tags": null
+          }
+        },
+        {
+          "address": "aws_iam_user.invalid_normal_policy_user",
+          "mode": "managed",
+          "type": "aws_iam_user",
+          "name": "invalid_normal_policy_user",
+          "provider_name": "aws",
+          "schema_version": 0,
+          "values": {
+            "force_destroy": false,
+            "name": "invalid_normal_policy_user",
+            "path": "/",
+            "permissions_boundary": null,
+            "tags": null
+          }
+        },
+        {
+          "address": "aws_iam_user.invalid_user_policy_attachment_user",
+          "mode": "managed",
+          "type": "aws_iam_user",
+          "name": "invalid_user_policy_attachment_user",
+          "provider_name": "aws",
+          "schema_version": 0,
+          "values": {
+            "force_destroy": false,
+            "name": "invalid_user_policy_attachment_user",
+            "path": "/",
+            "permissions_boundary": null,
+            "tags": null
+          }
+        },
+        {
+          "address": "aws_iam_user.invalid_user_policy_user",
+          "mode": "managed",
+          "type": "aws_iam_user",
+          "name": "invalid_user_policy_user",
+          "provider_name": "aws",
+          "schema_version": 0,
+          "values": {
+            "force_destroy": false,
+            "name": "invalid_user_policy_user",
+            "path": "/",
+            "permissions_boundary": null,
+            "tags": null
+          }
+        },
+        {
+          "address": "aws_iam_user.valid_group_blank_user",
+          "mode": "managed",
+          "type": "aws_iam_user",
+          "name": "valid_group_blank_user",
+          "provider_name": "aws",
+          "schema_version": 0,
+          "values": {
+            "force_destroy": false,
+            "name": "valid_group_blank_user",
+            "path": "/",
+            "permissions_boundary": null,
+            "tags": null
+          }
+        },
+        {
+          "address": "aws_iam_user.valid_group_empty_list_user",
+          "mode": "managed",
+          "type": "aws_iam_user",
+          "name": "valid_group_empty_list_user",
+          "provider_name": "aws",
+          "schema_version": 0,
+          "values": {
+            "force_destroy": false,
+            "name": "valid_group_empty_list_user",
+            "path": "/",
+            "permissions_boundary": null,
+            "tags": null
+          }
+        },
+        {
+          "address": "aws_iam_user.valid_group_missing_user",
+          "mode": "managed",
+          "type": "aws_iam_user",
+          "name": "valid_group_missing_user",
+          "provider_name": "aws",
+          "schema_version": 0,
+          "values": {
+            "force_destroy": false,
+            "name": "valid_group_missing_user",
+            "path": "/",
+            "permissions_boundary": null,
+            "tags": null
+          }
+        },
+        {
+          "address": "aws_iam_user_policy.invalid_user_policy",
+          "mode": "managed",
+          "type": "aws_iam_user_policy",
+          "name": "invalid_user_policy",
+          "provider_name": "aws",
+          "schema_version": 0,
+          "values": {
+            "name": "invalid_user_policy",
+            "name_prefix": null,
+            "policy": "{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Action\": [\n        \"ec2:Describe*\"\n      ],\n      \"Effect\": \"Allow\",\n      \"Resource\": \"*\"\n    }\n  ]\n}\n",
+            "user": "invalid_user_policy_user"
+          }
+        },
+        {
+          "address": "aws_iam_user_policy_attachment.invalid_user_policy_attachment",
+          "mode": "managed",
+          "type": "aws_iam_user_policy_attachment",
+          "name": "invalid_user_policy_attachment",
+          "provider_name": "aws",
+          "schema_version": 0,
+          "values": {
+            "user": "invalid_user_policy_attachment_user"
+          }
+        }
+      ]
+    }
+  },
+  "resource_changes": [
+    {
+      "address": "aws_iam_group.valid_group_blank_users",
+      "mode": "managed",
+      "type": "aws_iam_group",
+      "name": "valid_group_blank_users",
+      "provider_name": "aws",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "name": "valid_group_blank_users",
+          "path": "/"
+        },
+        "after_unknown": {
+          "arn": true,
+          "id": true,
+          "unique_id": true
+        }
+      }
+    },
+    {
+      "address": "aws_iam_group.valid_group_empty_list_users",
+      "mode": "managed",
+      "type": "aws_iam_group",
+      "name": "valid_group_empty_list_users",
+      "provider_name": "aws",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "name": "valid_group_empty_list_users",
+          "path": "/"
+        },
+        "after_unknown": {
+          "arn": true,
+          "id": true,
+          "unique_id": true
+        }
+      }
+    },
+    {
+      "address": "aws_iam_group.valid_group_missing_users",
+      "mode": "managed",
+      "type": "aws_iam_group",
+      "name": "valid_group_missing_users",
+      "provider_name": "aws",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "name": "valid_group_missing_users",
+          "path": "/"
+        },
+        "after_unknown": {
+          "arn": true,
+          "id": true,
+          "unique_id": true
+        }
+      }
+    },
+    {
+      "address": "aws_iam_group_membership.valid_group_blank_users_membership",
+      "mode": "managed",
+      "type": "aws_iam_group_membership",
+      "name": "valid_group_blank_users_membership",
+      "provider_name": "aws",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "group": "valid_group_blank_users",
+          "name": "valid_group_blank_users_membership",
+          "users": [
+            "valid_group_blank_user"
+          ]
+        },
+        "after_unknown": {
+          "id": true,
+          "users": [
+            false
+          ]
+        }
+      }
+    },
+    {
+      "address": "aws_iam_group_membership.valid_group_empty_list_users_membership",
+      "mode": "managed",
+      "type": "aws_iam_group_membership",
+      "name": "valid_group_empty_list_users_membership",
+      "provider_name": "aws",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "group": "valid_group_empty_list_users",
+          "name": "valid_group_empty_list_users_membership",
+          "users": [
+            "valid_group_empty_list_user"
+          ]
+        },
+        "after_unknown": {
+          "id": true,
+          "users": [
+            false
+          ]
+        }
+      }
+    },
+    {
+      "address": "aws_iam_group_membership.valid_group_missing_users_membership",
+      "mode": "managed",
+      "type": "aws_iam_group_membership",
+      "name": "valid_group_missing_users_membership",
+      "provider_name": "aws",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "group": "valid_group_missing_users",
+          "name": "valid_group_missing_users_membership",
+          "users": [
+            "valid_group_missing_user"
+          ]
+        },
+        "after_unknown": {
+          "id": true,
+          "users": [
+            false
+          ]
+        }
+      }
+    },
+    {
+      "address": "aws_iam_policy.invalid_normal_policy",
+      "mode": "managed",
+      "type": "aws_iam_policy",
+      "name": "invalid_normal_policy",
+      "provider_name": "aws",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "description": "Invalid normal policy attached to user",
+          "name": "invalid_normal_policy",
+          "name_prefix": null,
+          "path": "/",
+          "policy": "{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Action\": [\n        \"*\"\n      ],\n      \"Effect\": \"Deny\",\n      \"Resource\": \"*\"\n    }\n  ]\n}\n"
+        },
+        "after_unknown": {
+          "arn": true,
+          "id": true
+        }
+      }
+    },
+    {
+      "address": "aws_iam_policy.invalid_user_policy_attachment_policy",
+      "mode": "managed",
+      "type": "aws_iam_policy",
+      "name": "invalid_user_policy_attachment_policy",
+      "provider_name": "aws",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "description": "Invalid user policy attachment policy",
+          "name": "invalid_user_policy_attachment_policy",
+          "name_prefix": null,
+          "path": "/",
+          "policy": "{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Action\": [\n        \"ec2:Describe*\"\n      ],\n      \"Effect\": \"Allow\",\n      \"Resource\": \"*\"\n    }\n  ]\n}\n"
+        },
+        "after_unknown": {
+          "arn": true,
+          "id": true
+        }
+      }
+    },
+    {
+      "address": "aws_iam_policy.valid_group_blank_users_policy",
+      "mode": "managed",
+      "type": "aws_iam_policy",
+      "name": "valid_group_blank_users_policy",
+      "provider_name": "aws",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "description": "Valid group blank users policy",
+          "name": "valid_group_blank_users_policy",
+          "name_prefix": null,
+          "path": "/",
+          "policy": "{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Action\": [\n        \"ec2:Describe*\"\n      ],\n      \"Effect\": \"Deny\",\n      \"Resource\": \"*\"\n    }\n  ]\n}\n"
+        },
+        "after_unknown": {
+          "arn": true,
+          "id": true
+        }
+      }
+    },
+    {
+      "address": "aws_iam_policy.valid_group_empty_list_users_policy",
+      "mode": "managed",
+      "type": "aws_iam_policy",
+      "name": "valid_group_empty_list_users_policy",
+      "provider_name": "aws",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "description": "Valid group empty list users policy",
+          "name": "valid_group_empty_list_users_policy",
+          "name_prefix": null,
+          "path": "/",
+          "policy": "{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Action\": [\n        \"ec2:Describe*\"\n      ],\n      \"Effect\": \"Deny\",\n      \"Resource\": \"*\"\n    }\n  ]\n}\n"
+        },
+        "after_unknown": {
+          "arn": true,
+          "id": true
+        }
+      }
+    },
+    {
+      "address": "aws_iam_policy.valid_group_missing_users_policy",
+      "mode": "managed",
+      "type": "aws_iam_policy",
+      "name": "valid_group_missing_users_policy",
+      "provider_name": "aws",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "description": "Valid group missing users policy",
+          "name": "valid_group_missing_users_policy",
+          "name_prefix": null,
+          "path": "/",
+          "policy": "{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Action\": [\n        \"ec2:Describe*\"\n      ],\n      \"Effect\": \"Deny\",\n      \"Resource\": \"*\"\n    }\n  ]\n}\n"
+        },
+        "after_unknown": {
+          "arn": true,
+          "id": true
+        }
+      }
+    },
+    {
+      "address": "aws_iam_policy.valid_role_policy",
+      "mode": "managed",
+      "type": "aws_iam_policy",
+      "name": "valid_role_policy",
+      "provider_name": "aws",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "description": "Valid role policy",
+          "name": "valid_role_policy",
+          "name_prefix": null,
+          "path": "/",
+          "policy": "{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Action\": [\n        \"ec2:Describe*\"\n      ],\n      \"Effect\": \"Allow\",\n      \"Resource\": \"*\"\n    }\n  ]\n}\n"
+        },
+        "after_unknown": {
+          "arn": true,
+          "id": true
+        }
+      }
+    },
+    {
+      "address": "aws_iam_policy_attachment.invalid_normal_policy_attachment",
+      "mode": "managed",
+      "type": "aws_iam_policy_attachment",
+      "name": "invalid_normal_policy_attachment",
+      "provider_name": "aws",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "groups": null,
+          "name": "invalid_normal_policy_attachment",
+          "roles": null,
+          "users": [
+            "invalid_normal_policy_user"
+          ]
+        },
+        "after_unknown": {
+          "id": true,
+          "policy_arn": true,
+          "users": [
+            false
+          ]
+        }
+      }
+    },
+    {
+      "address": "aws_iam_policy_attachment.valid_group_policy_attachment_blank_users",
+      "mode": "managed",
+      "type": "aws_iam_policy_attachment",
+      "name": "valid_group_policy_attachment_blank_users",
+      "provider_name": "aws",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "groups": [
+            "valid_group_blank_users"
+          ],
+          "name": "valid_group_policy_attachment_blank_users",
+          "roles": null,
+          "users": [
+            ""
+          ]
+        },
+        "after_unknown": {
+          "groups": [
+            false
+          ],
+          "id": true,
+          "policy_arn": true,
+          "users": [
+            false
+          ]
+        }
+      }
+    },
+    {
+      "address": "aws_iam_policy_attachment.valid_group_policy_attachment_empty_list_users",
+      "mode": "managed",
+      "type": "aws_iam_policy_attachment",
+      "name": "valid_group_policy_attachment_empty_list_users",
+      "provider_name": "aws",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "groups": [
+            "valid_group_empty_list_users"
+          ],
+          "name": "valid_group_policy_attachment_empty_list_users",
+          "roles": null,
+          "users": null
+        },
+        "after_unknown": {
+          "groups": [
+            false
+          ],
+          "id": true,
+          "policy_arn": true
+        }
+      }
+    },
+    {
+      "address": "aws_iam_policy_attachment.valid_group_policy_attachment_missing_users",
+      "mode": "managed",
+      "type": "aws_iam_policy_attachment",
+      "name": "valid_group_policy_attachment_missing_users",
+      "provider_name": "aws",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "groups": [
+            "valid_group_missing_users"
+          ],
+          "name": "valid_group_policy_attachment_missing_users",
+          "roles": null,
+          "users": null
+        },
+        "after_unknown": {
+          "groups": [
+            false
+          ],
+          "id": true,
+          "policy_arn": true
+        }
+      }
+    },
+    {
+      "address": "aws_iam_policy_attachment.valid_role_policy_attachment",
+      "mode": "managed",
+      "type": "aws_iam_policy_attachment",
+      "name": "valid_role_policy_attachment",
+      "provider_name": "aws",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "groups": null,
+          "name": "valid_role_policy_attachment",
+          "roles": [
+            "valid_role"
+          ],
+          "users": null
+        },
+        "after_unknown": {
+          "id": true,
+          "policy_arn": true,
+          "roles": [
+            false
+          ]
+        }
+      }
+    },
+    {
+      "address": "aws_iam_role.valid_role",
+      "mode": "managed",
+      "type": "aws_iam_role",
+      "name": "valid_role",
+      "provider_name": "aws",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "assume_role_policy": "{\n\"Version\": \"2012-10-17\",\n\"Statement\": [\n  {\n    \"Action\": \"sts:AssumeRole\",\n    \"Principal\": {\n      \"Service\": \"ec2.amazonaws.com\"\n    },\n    \"Effect\": \"Allow\",\n    \"Sid\": \"\"\n  }\n ]\n}\n",
+          "description": null,
+          "force_detach_policies": false,
+          "max_session_duration": 3600,
+          "name": "valid_role",
+          "name_prefix": null,
+          "path": "/",
+          "permissions_boundary": null,
+          "tags": null
+        },
+        "after_unknown": {
+          "arn": true,
+          "create_date": true,
+          "id": true,
+          "unique_id": true
+        }
+      }
+    },
+    {
+      "address": "aws_iam_user.invalid_normal_policy_user",
+      "mode": "managed",
+      "type": "aws_iam_user",
+      "name": "invalid_normal_policy_user",
+      "provider_name": "aws",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "force_destroy": false,
+          "name": "invalid_normal_policy_user",
+          "path": "/",
+          "permissions_boundary": null,
+          "tags": null
+        },
+        "after_unknown": {
+          "arn": true,
+          "id": true,
+          "unique_id": true
+        }
+      }
+    },
+    {
+      "address": "aws_iam_user.invalid_user_policy_attachment_user",
+      "mode": "managed",
+      "type": "aws_iam_user",
+      "name": "invalid_user_policy_attachment_user",
+      "provider_name": "aws",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "force_destroy": false,
+          "name": "invalid_user_policy_attachment_user",
+          "path": "/",
+          "permissions_boundary": null,
+          "tags": null
+        },
+        "after_unknown": {
+          "arn": true,
+          "id": true,
+          "unique_id": true
+        }
+      }
+    },
+    {
+      "address": "aws_iam_user.invalid_user_policy_user",
+      "mode": "managed",
+      "type": "aws_iam_user",
+      "name": "invalid_user_policy_user",
+      "provider_name": "aws",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "force_destroy": false,
+          "name": "invalid_user_policy_user",
+          "path": "/",
+          "permissions_boundary": null,
+          "tags": null
+        },
+        "after_unknown": {
+          "arn": true,
+          "id": true,
+          "unique_id": true
+        }
+      }
+    },
+    {
+      "address": "aws_iam_user.valid_group_blank_user",
+      "mode": "managed",
+      "type": "aws_iam_user",
+      "name": "valid_group_blank_user",
+      "provider_name": "aws",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "force_destroy": false,
+          "name": "valid_group_blank_user",
+          "path": "/",
+          "permissions_boundary": null,
+          "tags": null
+        },
+        "after_unknown": {
+          "arn": true,
+          "id": true,
+          "unique_id": true
+        }
+      }
+    },
+    {
+      "address": "aws_iam_user.valid_group_empty_list_user",
+      "mode": "managed",
+      "type": "aws_iam_user",
+      "name": "valid_group_empty_list_user",
+      "provider_name": "aws",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "force_destroy": false,
+          "name": "valid_group_empty_list_user",
+          "path": "/",
+          "permissions_boundary": null,
+          "tags": null
+        },
+        "after_unknown": {
+          "arn": true,
+          "id": true,
+          "unique_id": true
+        }
+      }
+    },
+    {
+      "address": "aws_iam_user.valid_group_missing_user",
+      "mode": "managed",
+      "type": "aws_iam_user",
+      "name": "valid_group_missing_user",
+      "provider_name": "aws",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "force_destroy": false,
+          "name": "valid_group_missing_user",
+          "path": "/",
+          "permissions_boundary": null,
+          "tags": null
+        },
+        "after_unknown": {
+          "arn": true,
+          "id": true,
+          "unique_id": true
+        }
+      }
+    },
+    {
+      "address": "aws_iam_user_policy.invalid_user_policy",
+      "mode": "managed",
+      "type": "aws_iam_user_policy",
+      "name": "invalid_user_policy",
+      "provider_name": "aws",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "name": "invalid_user_policy",
+          "name_prefix": null,
+          "policy": "{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Action\": [\n        \"ec2:Describe*\"\n      ],\n      \"Effect\": \"Allow\",\n      \"Resource\": \"*\"\n    }\n  ]\n}\n",
+          "user": "invalid_user_policy_user"
+        },
+        "after_unknown": {
+          "id": true
+        }
+      }
+    },
+    {
+      "address": "aws_iam_user_policy_attachment.invalid_user_policy_attachment",
+      "mode": "managed",
+      "type": "aws_iam_user_policy_attachment",
+      "name": "invalid_user_policy_attachment",
+      "provider_name": "aws",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "user": "invalid_user_policy_attachment_user"
+        },
+        "after_unknown": {
+          "id": true,
+          "policy_arn": true
+        }
+      }
+    }
+  ],
+  "configuration": {
+    "provider_config": {
+      "aws": {
+        "name": "aws",
+        "expressions": {
+          "region": {
+            "constant_value": "us-west-2"
+          }
+        }
+      }
+    },
+    "root_module": {
+      "resources": [
+        {
+          "address": "aws_iam_group.valid_group_blank_users",
+          "mode": "managed",
+          "type": "aws_iam_group",
+          "name": "valid_group_blank_users",
+          "provider_config_key": "aws",
+          "expressions": {
+            "name": {
+              "constant_value": "valid_group_blank_users"
+            }
+          },
+          "schema_version": 0
+        },
+        {
+          "address": "aws_iam_group.valid_group_empty_list_users",
+          "mode": "managed",
+          "type": "aws_iam_group",
+          "name": "valid_group_empty_list_users",
+          "provider_config_key": "aws",
+          "expressions": {
+            "name": {
+              "constant_value": "valid_group_empty_list_users"
+            }
+          },
+          "schema_version": 0
+        },
+        {
+          "address": "aws_iam_group.valid_group_missing_users",
+          "mode": "managed",
+          "type": "aws_iam_group",
+          "name": "valid_group_missing_users",
+          "provider_config_key": "aws",
+          "expressions": {
+            "name": {
+              "constant_value": "valid_group_missing_users"
+            }
+          },
+          "schema_version": 0
+        },
+        {
+          "address": "aws_iam_group_membership.valid_group_blank_users_membership",
+          "mode": "managed",
+          "type": "aws_iam_group_membership",
+          "name": "valid_group_blank_users_membership",
+          "provider_config_key": "aws",
+          "expressions": {
+            "group": {
+              "references": [
+                "aws_iam_group.valid_group_blank_users"
+              ]
+            },
+            "name": {
+              "constant_value": "valid_group_blank_users_membership"
+            },
+            "users": {
+              "references": [
+                "aws_iam_user.valid_group_blank_user"
+              ]
+            }
+          },
+          "schema_version": 0
+        },
+        {
+          "address": "aws_iam_group_membership.valid_group_empty_list_users_membership",
+          "mode": "managed",
+          "type": "aws_iam_group_membership",
+          "name": "valid_group_empty_list_users_membership",
+          "provider_config_key": "aws",
+          "expressions": {
+            "group": {
+              "references": [
+                "aws_iam_group.valid_group_empty_list_users"
+              ]
+            },
+            "name": {
+              "constant_value": "valid_group_empty_list_users_membership"
+            },
+            "users": {
+              "references": [
+                "aws_iam_user.valid_group_empty_list_user"
+              ]
+            }
+          },
+          "schema_version": 0
+        },
+        {
+          "address": "aws_iam_group_membership.valid_group_missing_users_membership",
+          "mode": "managed",
+          "type": "aws_iam_group_membership",
+          "name": "valid_group_missing_users_membership",
+          "provider_config_key": "aws",
+          "expressions": {
+            "group": {
+              "references": [
+                "aws_iam_group.valid_group_missing_users"
+              ]
+            },
+            "name": {
+              "constant_value": "valid_group_missing_users_membership"
+            },
+            "users": {
+              "references": [
+                "aws_iam_user.valid_group_missing_user"
+              ]
+            }
+          },
+          "schema_version": 0
+        },
+        {
+          "address": "aws_iam_policy.invalid_normal_policy",
+          "mode": "managed",
+          "type": "aws_iam_policy",
+          "name": "invalid_normal_policy",
+          "provider_config_key": "aws",
+          "expressions": {
+            "description": {
+              "constant_value": "Invalid normal policy attached to user"
+            },
+            "name": {
+              "constant_value": "invalid_normal_policy"
+            },
+            "policy": {
+              "constant_value": "{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Action\": [\n        \"*\"\n      ],\n      \"Effect\": \"Deny\",\n      \"Resource\": \"*\"\n    }\n  ]\n}\n"
+            }
+          },
+          "schema_version": 0
+        },
+        {
+          "address": "aws_iam_policy.invalid_user_policy_attachment_policy",
+          "mode": "managed",
+          "type": "aws_iam_policy",
+          "name": "invalid_user_policy_attachment_policy",
+          "provider_config_key": "aws",
+          "expressions": {
+            "description": {
+              "constant_value": "Invalid user policy attachment policy"
+            },
+            "name": {
+              "constant_value": "invalid_user_policy_attachment_policy"
+            },
+            "policy": {
+              "constant_value": "{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Action\": [\n        \"ec2:Describe*\"\n      ],\n      \"Effect\": \"Allow\",\n      \"Resource\": \"*\"\n    }\n  ]\n}\n"
+            }
+          },
+          "schema_version": 0
+        },
+        {
+          "address": "aws_iam_policy.valid_group_blank_users_policy",
+          "mode": "managed",
+          "type": "aws_iam_policy",
+          "name": "valid_group_blank_users_policy",
+          "provider_config_key": "aws",
+          "expressions": {
+            "description": {
+              "constant_value": "Valid group blank users policy"
+            },
+            "name": {
+              "constant_value": "valid_group_blank_users_policy"
+            },
+            "policy": {
+              "constant_value": "{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Action\": [\n        \"ec2:Describe*\"\n      ],\n      \"Effect\": \"Deny\",\n      \"Resource\": \"*\"\n    }\n  ]\n}\n"
+            }
+          },
+          "schema_version": 0
+        },
+        {
+          "address": "aws_iam_policy.valid_group_empty_list_users_policy",
+          "mode": "managed",
+          "type": "aws_iam_policy",
+          "name": "valid_group_empty_list_users_policy",
+          "provider_config_key": "aws",
+          "expressions": {
+            "description": {
+              "constant_value": "Valid group empty list users policy"
+            },
+            "name": {
+              "constant_value": "valid_group_empty_list_users_policy"
+            },
+            "policy": {
+              "constant_value": "{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Action\": [\n        \"ec2:Describe*\"\n      ],\n      \"Effect\": \"Deny\",\n      \"Resource\": \"*\"\n    }\n  ]\n}\n"
+            }
+          },
+          "schema_version": 0
+        },
+        {
+          "address": "aws_iam_policy.valid_group_missing_users_policy",
+          "mode": "managed",
+          "type": "aws_iam_policy",
+          "name": "valid_group_missing_users_policy",
+          "provider_config_key": "aws",
+          "expressions": {
+            "description": {
+              "constant_value": "Valid group missing users policy"
+            },
+            "name": {
+              "constant_value": "valid_group_missing_users_policy"
+            },
+            "policy": {
+              "constant_value": "{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Action\": [\n        \"ec2:Describe*\"\n      ],\n      \"Effect\": \"Deny\",\n      \"Resource\": \"*\"\n    }\n  ]\n}\n"
+            }
+          },
+          "schema_version": 0
+        },
+        {
+          "address": "aws_iam_policy.valid_role_policy",
+          "mode": "managed",
+          "type": "aws_iam_policy",
+          "name": "valid_role_policy",
+          "provider_config_key": "aws",
+          "expressions": {
+            "description": {
+              "constant_value": "Valid role policy"
+            },
+            "name": {
+              "constant_value": "valid_role_policy"
+            },
+            "policy": {
+              "constant_value": "{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Action\": [\n        \"ec2:Describe*\"\n      ],\n      \"Effect\": \"Allow\",\n      \"Resource\": \"*\"\n    }\n  ]\n}\n"
+            }
+          },
+          "schema_version": 0
+        },
+        {
+          "address": "aws_iam_policy_attachment.invalid_normal_policy_attachment",
+          "mode": "managed",
+          "type": "aws_iam_policy_attachment",
+          "name": "invalid_normal_policy_attachment",
+          "provider_config_key": "aws",
+          "expressions": {
+            "name": {
+              "constant_value": "invalid_normal_policy_attachment"
+            },
+            "policy_arn": {
+              "references": [
+                "aws_iam_policy.invalid_normal_policy"
+              ]
+            },
+            "users": {
+              "references": [
+                "aws_iam_user.invalid_normal_policy_user"
+              ]
+            }
+          },
+          "schema_version": 0
+        },
+        {
+          "address": "aws_iam_policy_attachment.valid_group_policy_attachment_blank_users",
+          "mode": "managed",
+          "type": "aws_iam_policy_attachment",
+          "name": "valid_group_policy_attachment_blank_users",
+          "provider_config_key": "aws",
+          "expressions": {
+            "groups": {
+              "references": [
+                "aws_iam_group.valid_group_blank_users"
+              ]
+            },
+            "name": {
+              "constant_value": "valid_group_policy_attachment_blank_users"
+            },
+            "policy_arn": {
+              "references": [
+                "aws_iam_policy.valid_group_blank_users_policy"
+              ]
+            },
+            "users": {
+              "constant_value": [
+                ""
+              ]
+            }
+          },
+          "schema_version": 0
+        },
+        {
+          "address": "aws_iam_policy_attachment.valid_group_policy_attachment_empty_list_users",
+          "mode": "managed",
+          "type": "aws_iam_policy_attachment",
+          "name": "valid_group_policy_attachment_empty_list_users",
+          "provider_config_key": "aws",
+          "expressions": {
+            "groups": {
+              "references": [
+                "aws_iam_group.valid_group_empty_list_users"
+              ]
+            },
+            "name": {
+              "constant_value": "valid_group_policy_attachment_empty_list_users"
+            },
+            "policy_arn": {
+              "references": [
+                "aws_iam_policy.valid_group_empty_list_users_policy"
+              ]
+            },
+            "users": {
+              "constant_value": []
+            }
+          },
+          "schema_version": 0
+        },
+        {
+          "address": "aws_iam_policy_attachment.valid_group_policy_attachment_missing_users",
+          "mode": "managed",
+          "type": "aws_iam_policy_attachment",
+          "name": "valid_group_policy_attachment_missing_users",
+          "provider_config_key": "aws",
+          "expressions": {
+            "groups": {
+              "references": [
+                "aws_iam_group.valid_group_missing_users"
+              ]
+            },
+            "name": {
+              "constant_value": "valid_group_policy_attachment_missing_users"
+            },
+            "policy_arn": {
+              "references": [
+                "aws_iam_policy.valid_group_missing_users_policy"
+              ]
+            }
+          },
+          "schema_version": 0
+        },
+        {
+          "address": "aws_iam_policy_attachment.valid_role_policy_attachment",
+          "mode": "managed",
+          "type": "aws_iam_policy_attachment",
+          "name": "valid_role_policy_attachment",
+          "provider_config_key": "aws",
+          "expressions": {
+            "name": {
+              "constant_value": "valid_role_policy_attachment"
+            },
+            "policy_arn": {
+              "references": [
+                "aws_iam_policy.valid_role_policy"
+              ]
+            },
+            "roles": {
+              "references": [
+                "aws_iam_role.valid_role"
+              ]
+            }
+          },
+          "schema_version": 0
+        },
+        {
+          "address": "aws_iam_role.valid_role",
+          "mode": "managed",
+          "type": "aws_iam_role",
+          "name": "valid_role",
+          "provider_config_key": "aws",
+          "expressions": {
+            "assume_role_policy": {
+              "constant_value": "{\n\"Version\": \"2012-10-17\",\n\"Statement\": [\n  {\n    \"Action\": \"sts:AssumeRole\",\n    \"Principal\": {\n      \"Service\": \"ec2.amazonaws.com\"\n    },\n    \"Effect\": \"Allow\",\n    \"Sid\": \"\"\n  }\n ]\n}\n"
+            },
+            "name": {
+              "constant_value": "valid_role"
+            }
+          },
+          "schema_version": 0
+        },
+        {
+          "address": "aws_iam_user.invalid_normal_policy_user",
+          "mode": "managed",
+          "type": "aws_iam_user",
+          "name": "invalid_normal_policy_user",
+          "provider_config_key": "aws",
+          "expressions": {
+            "name": {
+              "constant_value": "invalid_normal_policy_user"
+            }
+          },
+          "schema_version": 0
+        },
+        {
+          "address": "aws_iam_user.invalid_user_policy_attachment_user",
+          "mode": "managed",
+          "type": "aws_iam_user",
+          "name": "invalid_user_policy_attachment_user",
+          "provider_config_key": "aws",
+          "expressions": {
+            "name": {
+              "constant_value": "invalid_user_policy_attachment_user"
+            }
+          },
+          "schema_version": 0
+        },
+        {
+          "address": "aws_iam_user.invalid_user_policy_user",
+          "mode": "managed",
+          "type": "aws_iam_user",
+          "name": "invalid_user_policy_user",
+          "provider_config_key": "aws",
+          "expressions": {
+            "name": {
+              "constant_value": "invalid_user_policy_user"
+            }
+          },
+          "schema_version": 0
+        },
+        {
+          "address": "aws_iam_user.valid_group_blank_user",
+          "mode": "managed",
+          "type": "aws_iam_user",
+          "name": "valid_group_blank_user",
+          "provider_config_key": "aws",
+          "expressions": {
+            "name": {
+              "constant_value": "valid_group_blank_user"
+            }
+          },
+          "schema_version": 0
+        },
+        {
+          "address": "aws_iam_user.valid_group_empty_list_user",
+          "mode": "managed",
+          "type": "aws_iam_user",
+          "name": "valid_group_empty_list_user",
+          "provider_config_key": "aws",
+          "expressions": {
+            "name": {
+              "constant_value": "valid_group_empty_list_user"
+            }
+          },
+          "schema_version": 0
+        },
+        {
+          "address": "aws_iam_user.valid_group_missing_user",
+          "mode": "managed",
+          "type": "aws_iam_user",
+          "name": "valid_group_missing_user",
+          "provider_config_key": "aws",
+          "expressions": {
+            "name": {
+              "constant_value": "valid_group_missing_user"
+            }
+          },
+          "schema_version": 0
+        },
+        {
+          "address": "aws_iam_user_policy.invalid_user_policy",
+          "mode": "managed",
+          "type": "aws_iam_user_policy",
+          "name": "invalid_user_policy",
+          "provider_config_key": "aws",
+          "expressions": {
+            "name": {
+              "constant_value": "invalid_user_policy"
+            },
+            "policy": {
+              "constant_value": "{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Action\": [\n        \"ec2:Describe*\"\n      ],\n      \"Effect\": \"Allow\",\n      \"Resource\": \"*\"\n    }\n  ]\n}\n"
+            },
+            "user": {
+              "references": [
+                "aws_iam_user.invalid_user_policy_user"
+              ]
+            }
+          },
+          "schema_version": 0
+        },
+        {
+          "address": "aws_iam_user_policy_attachment.invalid_user_policy_attachment",
+          "mode": "managed",
+          "type": "aws_iam_user_policy_attachment",
+          "name": "invalid_user_policy_attachment",
+          "provider_config_key": "aws",
+          "expressions": {
+            "policy_arn": {
+              "references": [
+                "aws_iam_policy.invalid_user_policy_attachment_policy"
+              ]
+            },
+            "user": {
+              "references": [
+                "aws_iam_user.invalid_user_policy_attachment_user"
+              ]
+            }
+          },
+          "schema_version": 0
+        }
+      ]
+    }
+  }
+}

--- a/tests/rules/inputs/user_attached_policy.tf
+++ b/tests/rules/inputs/user_attached_policy.tf
@@ -1,0 +1,266 @@
+provider "aws" {
+  region  = "us-west-2"
+}
+
+resource "aws_iam_user" "invalid_normal_policy_user" {
+  name = "invalid_normal_policy_user"
+}
+
+resource "aws_iam_policy_attachment" "invalid_normal_policy_attachment" {
+  name       = "invalid_normal_policy_attachment"
+  users      = [aws_iam_user.invalid_normal_policy_user.name]
+  policy_arn = aws_iam_policy.invalid_normal_policy.arn
+}
+
+resource "aws_iam_policy" "invalid_normal_policy" {
+  name        = "invalid_normal_policy"
+  description = "Invalid normal policy attached to user"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "*"
+      ],
+      "Effect": "Deny",
+      "Resource": "*"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_user" "invalid_user_policy_user" {
+  name = "invalid_user_policy_user"
+}
+
+resource "aws_iam_user_policy" "invalid_user_policy" {
+  name = "invalid_user_policy"
+  user = aws_iam_user.invalid_user_policy_user.name
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "ec2:Describe*"
+      ],
+      "Effect": "Allow",
+      "Resource": "*"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_user" "invalid_user_policy_attachment_user" {
+  name = "invalid_user_policy_attachment_user"
+}
+
+resource "aws_iam_user_policy_attachment" "invalid_user_policy_attachment" {
+  user       = aws_iam_user.invalid_user_policy_attachment_user.name
+  policy_arn = aws_iam_policy.invalid_user_policy_attachment_policy.arn
+}
+
+resource "aws_iam_policy" "invalid_user_policy_attachment_policy" {
+  name        = "invalid_user_policy_attachment_policy"
+  description = "Invalid user policy attachment policy"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "ec2:Describe*"
+      ],
+      "Effect": "Allow",
+      "Resource": "*"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_user" "valid_group_blank_user" {
+  name = "valid_group_blank_user"
+}
+
+resource "aws_iam_group" "valid_group_blank_users" {
+  name = "valid_group_blank_users"
+}
+
+resource "aws_iam_group_membership" "valid_group_blank_users_membership" {
+  name = "valid_group_blank_users_membership"
+
+  users = [
+    aws_iam_user.valid_group_blank_user.name
+  ]
+
+  group = aws_iam_group.valid_group_blank_users.name
+}
+
+resource "aws_iam_policy_attachment" "valid_group_policy_attachment_blank_users" {
+  name       = "valid_group_policy_attachment_blank_users"
+  groups     = [aws_iam_group.valid_group_blank_users.name]
+  users      = [""]
+  policy_arn = aws_iam_policy.valid_group_blank_users_policy.arn
+}
+
+resource "aws_iam_policy" "valid_group_blank_users_policy" {
+  name        = "valid_group_blank_users_policy"
+  description = "Valid group blank users policy"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "ec2:Describe*"
+      ],
+      "Effect": "Deny",
+      "Resource": "*"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_user" "valid_group_missing_user" {
+  name = "valid_group_missing_user"
+}
+
+resource "aws_iam_group" "valid_group_missing_users" {
+  name = "valid_group_missing_users"
+}
+
+resource "aws_iam_group_membership" "valid_group_missing_users_membership" {
+  name = "valid_group_missing_users_membership"
+
+  users = [
+    aws_iam_user.valid_group_missing_user.name
+  ]
+
+  group = aws_iam_group.valid_group_missing_users.name
+}
+
+resource "aws_iam_policy_attachment" "valid_group_policy_attachment_missing_users" {
+  name       = "valid_group_policy_attachment_missing_users"
+  groups     = [aws_iam_group.valid_group_missing_users.name]
+  policy_arn = aws_iam_policy.valid_group_missing_users_policy.arn
+}
+
+resource "aws_iam_policy" "valid_group_missing_users_policy" {
+  name        = "valid_group_missing_users_policy"
+  description = "Valid group missing users policy"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "ec2:Describe*"
+      ],
+      "Effect": "Deny",
+      "Resource": "*"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_user" "valid_group_empty_list_user" {
+  name = "valid_group_empty_list_user"
+}
+
+resource "aws_iam_group" "valid_group_empty_list_users" {
+  name = "valid_group_empty_list_users"
+}
+
+resource "aws_iam_group_membership" "valid_group_empty_list_users_membership" {
+  name = "valid_group_empty_list_users_membership"
+
+  users = [
+    aws_iam_user.valid_group_empty_list_user.name
+  ]
+
+  group = aws_iam_group.valid_group_empty_list_users.name
+}
+
+resource "aws_iam_policy_attachment" "valid_group_policy_attachment_empty_list_users" {
+  name       = "valid_group_policy_attachment_empty_list_users"
+  groups     = [aws_iam_group.valid_group_empty_list_users.name]
+  users      = []
+  policy_arn = aws_iam_policy.valid_group_empty_list_users_policy.arn
+}
+
+resource "aws_iam_policy" "valid_group_empty_list_users_policy" {
+  name        = "valid_group_empty_list_users_policy"
+  description = "Valid group empty list users policy"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "ec2:Describe*"
+      ],
+      "Effect": "Deny",
+      "Resource": "*"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role" "valid_role" {
+  name = "valid_role"
+
+  assume_role_policy = <<EOF
+{
+"Version": "2012-10-17",
+"Statement": [
+  {
+    "Action": "sts:AssumeRole",
+    "Principal": {
+      "Service": "ec2.amazonaws.com"
+    },
+    "Effect": "Allow",
+    "Sid": ""
+  }
+ ]
+}
+EOF
+}
+
+resource "aws_iam_policy_attachment" "valid_role_policy_attachment" {
+  name       = "valid_role_policy_attachment"
+  roles      = [aws_iam_role.valid_role.name]
+  policy_arn = aws_iam_policy.valid_role_policy.arn
+}
+
+resource "aws_iam_policy" "valid_role_policy" {
+  name        = "valid_role_policy"
+  description = "Valid role policy"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "ec2:Describe*"
+      ],
+      "Effect": "Allow",
+      "Resource": "*"
+    }
+  ]
+}
+EOF
+}

--- a/tests/rules/user_attached_policy.rego
+++ b/tests/rules/user_attached_policy.rego
@@ -1,0 +1,16 @@
+package tests.rules.user_attached_policy
+
+import data.fugue.regula
+
+test_user_attached_policy {
+  report := regula.report with input as mock_input
+  resources := report.rules.user_attached_policy.resources
+
+  resources["aws_iam_policy_attachment.invalid_normal_policy_attachment"].valid == false
+  resources["aws_iam_user_policy.invalid_user_policy"].valid == false
+  resources["aws_iam_user_policy_attachment.invalid_user_policy_attachment"].valid == false
+  resources["aws_iam_policy_attachment.valid_group_policy_attachment_blank_users"].valid == true
+  resources["aws_iam_policy_attachment.valid_group_policy_attachment_missing_users"].valid == true
+  resources["aws_iam_policy_attachment.valid_group_policy_attachment_empty_list_users"].valid == true
+  resources["aws_iam_policy_attachment.valid_role_policy_attachment"].valid == true  
+}


### PR DESCRIPTION
For REGULA_R00001: IAM policies should not be attached to users. This maps to CIS 1.16.

- Updated REGULA_R00002 with rule number in comments
- Added Rego rule user_attached_policy.rego
- Added corresonding Terraform file
- Added corresponding Rego test file
- Added corresponding Rego test input file

All tests passed.