### PR TITLE
REGULA_R00008

### DIFF
--- a/rules/no_ingress_except_80_443.rego
+++ b/rules/no_ingress_except_80_443.rego
@@ -1,0 +1,27 @@
+package rules.no_ingress_except_80_443
+
+import data.fugue
+
+resource_type = "MULTIPLE"
+
+security_groups = fugue.resources("aws_security_group")
+
+valid_ports(sg) {
+  sg.ingress[i].from_port == 80
+  sg.ingress[i].to_port == 80
+} {
+  sg.ingress[i].from_port == 443
+  sg.ingress[i].to_port == 443
+}
+
+policy[p] {
+  security_group = security_groups[_]
+  security_group.ingress[i].cidr_blocks[_] == "0.0.0.0/0"
+  not valid_ports(security_group) 
+  p = fugue.deny_resource(security_group)
+} {
+  security_group = security_groups[_]
+  security_group.ingress[i].cidr_blocks[_] == "0.0.0.0/0"
+  valid_ports(security_group)
+  p = fugue.allow_resource(security_group)
+}

--- a/tests/rules/inputs/no_ingress_except_80_443.rego
+++ b/tests/rules/inputs/no_ingress_except_80_443.rego
@@ -1,0 +1,520 @@
+# This package was automatically generated from:
+#
+#     tests/rules/inputs/no_ingress_except_80_443.tf
+#
+# using `generate_test_inputs.sh` and should not be modified
+# directly.
+package tests.rules.no_ingress_except_80_443
+mock_input = {
+  "format_version": "0.1",
+  "terraform_version": "0.12.15",
+  "planned_values": {
+    "root_module": {
+      "resources": [
+        {
+          "address": "aws_security_group.invalid_allow_all",
+          "mode": "managed",
+          "type": "aws_security_group",
+          "name": "invalid_allow_all",
+          "provider_name": "aws",
+          "schema_version": 1,
+          "values": {
+            "description": "Managed by Terraform",
+            "ingress": [
+              {
+                "cidr_blocks": [
+                  "0.0.0.0/0"
+                ],
+                "description": "",
+                "from_port": 0,
+                "ipv6_cidr_blocks": [],
+                "prefix_list_ids": [],
+                "protocol": "tcp",
+                "security_groups": [],
+                "self": false,
+                "to_port": 65535
+              }
+            ],
+            "name": "invalid_allow_all",
+            "name_prefix": null,
+            "revoke_rules_on_delete": false,
+            "tags": null,
+            "timeouts": null
+          }
+        },
+        {
+          "address": "aws_security_group.invalid_include_443",
+          "mode": "managed",
+          "type": "aws_security_group",
+          "name": "invalid_include_443",
+          "provider_name": "aws",
+          "schema_version": 1,
+          "values": {
+            "description": "Managed by Terraform",
+            "ingress": [
+              {
+                "cidr_blocks": [
+                  "0.0.0.0/0"
+                ],
+                "description": "",
+                "from_port": 442,
+                "ipv6_cidr_blocks": [],
+                "prefix_list_ids": [],
+                "protocol": "tcp",
+                "security_groups": [],
+                "self": false,
+                "to_port": 444
+              }
+            ],
+            "name": "invalid_include_valid_443",
+            "name_prefix": null,
+            "revoke_rules_on_delete": false,
+            "tags": null,
+            "timeouts": null
+          }
+        },
+        {
+          "address": "aws_security_group.invalid_include_80",
+          "mode": "managed",
+          "type": "aws_security_group",
+          "name": "invalid_include_80",
+          "provider_name": "aws",
+          "schema_version": 1,
+          "values": {
+            "description": "Managed by Terraform",
+            "ingress": [
+              {
+                "cidr_blocks": [
+                  "0.0.0.0/0"
+                ],
+                "description": "",
+                "from_port": 79,
+                "ipv6_cidr_blocks": [],
+                "prefix_list_ids": [],
+                "protocol": "tcp",
+                "security_groups": [],
+                "self": false,
+                "to_port": 81
+              }
+            ],
+            "name": "invalid_include_valid_80",
+            "name_prefix": null,
+            "revoke_rules_on_delete": false,
+            "tags": null,
+            "timeouts": null
+          }
+        },
+        {
+          "address": "aws_security_group.valid_exact_443",
+          "mode": "managed",
+          "type": "aws_security_group",
+          "name": "valid_exact_443",
+          "provider_name": "aws",
+          "schema_version": 1,
+          "values": {
+            "description": "Managed by Terraform",
+            "ingress": [
+              {
+                "cidr_blocks": [
+                  "0.0.0.0/0"
+                ],
+                "description": "",
+                "from_port": 443,
+                "ipv6_cidr_blocks": [],
+                "prefix_list_ids": [],
+                "protocol": "tcp",
+                "security_groups": [],
+                "self": false,
+                "to_port": 443
+              }
+            ],
+            "name": "valid_exact_443",
+            "name_prefix": null,
+            "revoke_rules_on_delete": false,
+            "tags": null,
+            "timeouts": null
+          }
+        },
+        {
+          "address": "aws_security_group.valid_exact_80",
+          "mode": "managed",
+          "type": "aws_security_group",
+          "name": "valid_exact_80",
+          "provider_name": "aws",
+          "schema_version": 1,
+          "values": {
+            "description": "Managed by Terraform",
+            "ingress": [
+              {
+                "cidr_blocks": [
+                  "0.0.0.0/0"
+                ],
+                "description": "",
+                "from_port": 80,
+                "ipv6_cidr_blocks": [],
+                "prefix_list_ids": [],
+                "protocol": "tcp",
+                "security_groups": [],
+                "self": false,
+                "to_port": 80
+              }
+            ],
+            "name": "valid_exact_80",
+            "name_prefix": null,
+            "revoke_rules_on_delete": false,
+            "tags": null,
+            "timeouts": null
+          }
+        }
+      ]
+    }
+  },
+  "resource_changes": [
+    {
+      "address": "aws_security_group.invalid_allow_all",
+      "mode": "managed",
+      "type": "aws_security_group",
+      "name": "invalid_allow_all",
+      "provider_name": "aws",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "description": "Managed by Terraform",
+          "ingress": [
+            {
+              "cidr_blocks": [
+                "0.0.0.0/0"
+              ],
+              "description": "",
+              "from_port": 0,
+              "ipv6_cidr_blocks": [],
+              "prefix_list_ids": [],
+              "protocol": "tcp",
+              "security_groups": [],
+              "self": false,
+              "to_port": 65535
+            }
+          ],
+          "name": "invalid_allow_all",
+          "name_prefix": null,
+          "revoke_rules_on_delete": false,
+          "tags": null,
+          "timeouts": null
+        },
+        "after_unknown": {
+          "arn": true,
+          "egress": true,
+          "id": true,
+          "ingress": [
+            {
+              "cidr_blocks": [
+                false
+              ],
+              "ipv6_cidr_blocks": [],
+              "prefix_list_ids": [],
+              "security_groups": []
+            }
+          ],
+          "owner_id": true,
+          "vpc_id": true
+        }
+      }
+    },
+    {
+      "address": "aws_security_group.invalid_include_443",
+      "mode": "managed",
+      "type": "aws_security_group",
+      "name": "invalid_include_443",
+      "provider_name": "aws",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "description": "Managed by Terraform",
+          "ingress": [
+            {
+              "cidr_blocks": [
+                "0.0.0.0/0"
+              ],
+              "description": "",
+              "from_port": 442,
+              "ipv6_cidr_blocks": [],
+              "prefix_list_ids": [],
+              "protocol": "tcp",
+              "security_groups": [],
+              "self": false,
+              "to_port": 444
+            }
+          ],
+          "name": "invalid_include_valid_443",
+          "name_prefix": null,
+          "revoke_rules_on_delete": false,
+          "tags": null,
+          "timeouts": null
+        },
+        "after_unknown": {
+          "arn": true,
+          "egress": true,
+          "id": true,
+          "ingress": [
+            {
+              "cidr_blocks": [
+                false
+              ],
+              "ipv6_cidr_blocks": [],
+              "prefix_list_ids": [],
+              "security_groups": []
+            }
+          ],
+          "owner_id": true,
+          "vpc_id": true
+        }
+      }
+    },
+    {
+      "address": "aws_security_group.invalid_include_80",
+      "mode": "managed",
+      "type": "aws_security_group",
+      "name": "invalid_include_80",
+      "provider_name": "aws",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "description": "Managed by Terraform",
+          "ingress": [
+            {
+              "cidr_blocks": [
+                "0.0.0.0/0"
+              ],
+              "description": "",
+              "from_port": 79,
+              "ipv6_cidr_blocks": [],
+              "prefix_list_ids": [],
+              "protocol": "tcp",
+              "security_groups": [],
+              "self": false,
+              "to_port": 81
+            }
+          ],
+          "name": "invalid_include_valid_80",
+          "name_prefix": null,
+          "revoke_rules_on_delete": false,
+          "tags": null,
+          "timeouts": null
+        },
+        "after_unknown": {
+          "arn": true,
+          "egress": true,
+          "id": true,
+          "ingress": [
+            {
+              "cidr_blocks": [
+                false
+              ],
+              "ipv6_cidr_blocks": [],
+              "prefix_list_ids": [],
+              "security_groups": []
+            }
+          ],
+          "owner_id": true,
+          "vpc_id": true
+        }
+      }
+    },
+    {
+      "address": "aws_security_group.valid_exact_443",
+      "mode": "managed",
+      "type": "aws_security_group",
+      "name": "valid_exact_443",
+      "provider_name": "aws",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "description": "Managed by Terraform",
+          "ingress": [
+            {
+              "cidr_blocks": [
+                "0.0.0.0/0"
+              ],
+              "description": "",
+              "from_port": 443,
+              "ipv6_cidr_blocks": [],
+              "prefix_list_ids": [],
+              "protocol": "tcp",
+              "security_groups": [],
+              "self": false,
+              "to_port": 443
+            }
+          ],
+          "name": "valid_exact_443",
+          "name_prefix": null,
+          "revoke_rules_on_delete": false,
+          "tags": null,
+          "timeouts": null
+        },
+        "after_unknown": {
+          "arn": true,
+          "egress": true,
+          "id": true,
+          "ingress": [
+            {
+              "cidr_blocks": [
+                false
+              ],
+              "ipv6_cidr_blocks": [],
+              "prefix_list_ids": [],
+              "security_groups": []
+            }
+          ],
+          "owner_id": true,
+          "vpc_id": true
+        }
+      }
+    },
+    {
+      "address": "aws_security_group.valid_exact_80",
+      "mode": "managed",
+      "type": "aws_security_group",
+      "name": "valid_exact_80",
+      "provider_name": "aws",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "description": "Managed by Terraform",
+          "ingress": [
+            {
+              "cidr_blocks": [
+                "0.0.0.0/0"
+              ],
+              "description": "",
+              "from_port": 80,
+              "ipv6_cidr_blocks": [],
+              "prefix_list_ids": [],
+              "protocol": "tcp",
+              "security_groups": [],
+              "self": false,
+              "to_port": 80
+            }
+          ],
+          "name": "valid_exact_80",
+          "name_prefix": null,
+          "revoke_rules_on_delete": false,
+          "tags": null,
+          "timeouts": null
+        },
+        "after_unknown": {
+          "arn": true,
+          "egress": true,
+          "id": true,
+          "ingress": [
+            {
+              "cidr_blocks": [
+                false
+              ],
+              "ipv6_cidr_blocks": [],
+              "prefix_list_ids": [],
+              "security_groups": []
+            }
+          ],
+          "owner_id": true,
+          "vpc_id": true
+        }
+      }
+    }
+  ],
+  "configuration": {
+    "provider_config": {
+      "aws": {
+        "name": "aws",
+        "expressions": {
+          "region": {
+            "constant_value": "us-west-1"
+          }
+        }
+      }
+    },
+    "root_module": {
+      "resources": [
+        {
+          "address": "aws_security_group.invalid_allow_all",
+          "mode": "managed",
+          "type": "aws_security_group",
+          "name": "invalid_allow_all",
+          "provider_config_key": "aws",
+          "expressions": {
+            "name": {
+              "constant_value": "invalid_allow_all"
+            }
+          },
+          "schema_version": 1
+        },
+        {
+          "address": "aws_security_group.invalid_include_443",
+          "mode": "managed",
+          "type": "aws_security_group",
+          "name": "invalid_include_443",
+          "provider_config_key": "aws",
+          "expressions": {
+            "name": {
+              "constant_value": "invalid_include_valid_443"
+            }
+          },
+          "schema_version": 1
+        },
+        {
+          "address": "aws_security_group.invalid_include_80",
+          "mode": "managed",
+          "type": "aws_security_group",
+          "name": "invalid_include_80",
+          "provider_config_key": "aws",
+          "expressions": {
+            "name": {
+              "constant_value": "invalid_include_valid_80"
+            }
+          },
+          "schema_version": 1
+        },
+        {
+          "address": "aws_security_group.valid_exact_443",
+          "mode": "managed",
+          "type": "aws_security_group",
+          "name": "valid_exact_443",
+          "provider_config_key": "aws",
+          "expressions": {
+            "name": {
+              "constant_value": "valid_exact_443"
+            }
+          },
+          "schema_version": 1
+        },
+        {
+          "address": "aws_security_group.valid_exact_80",
+          "mode": "managed",
+          "type": "aws_security_group",
+          "name": "valid_exact_80",
+          "provider_config_key": "aws",
+          "expressions": {
+            "name": {
+              "constant_value": "valid_exact_80"
+            }
+          },
+          "schema_version": 1
+        }
+      ]
+    }
+  }
+}

--- a/tests/rules/inputs/no_ingress_except_80_443.tf
+++ b/tests/rules/inputs/no_ingress_except_80_443.tf
@@ -1,0 +1,58 @@
+provider "aws" {
+  region = "us-west-1"
+}
+
+resource "aws_security_group" "valid_exact_80" {
+  name        = "valid_exact_80"
+  
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_security_group" "invalid_include_80" {
+  name        = "invalid_include_valid_80"
+
+  ingress {
+    from_port   = 79
+    to_port     = 81
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_security_group" "valid_exact_443" {
+  name        = "valid_exact_443"
+  
+  ingress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_security_group" "invalid_include_443" {
+  name        = "invalid_include_valid_443"
+
+  ingress {
+    from_port   = 442
+    to_port     = 444
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_security_group" "invalid_allow_all" {
+  name        = "invalid_allow_all"
+
+  ingress {
+    from_port   = 0
+    to_port     = 65535
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}

--- a/tests/rules/no_ingress_except_80_443.rego
+++ b/tests/rules/no_ingress_except_80_443.rego
@@ -1,0 +1,14 @@
+package tests.rules.no_ingress_except_80_443
+
+import data.fugue.regula
+
+test_no_ingress_except_80_443 {
+  report := regula.report with input as mock_input
+  resources := report.rules.no_ingress_except_80_443.resources
+
+  resources["aws_security_group.invalid_allow_all"].valid == false
+  resources["aws_security_group.invalid_include_443"].valid == false
+  resources["aws_security_group.invalid_include_80"].valid == false
+  resources["aws_security_group.valid_exact_443"].valid == true
+  resources["aws_security_group.valid_exact_80"].valid == true
+}


### PR DESCRIPTION
For REGULA_R00008: VPC security group rules should not permit ingress from '0.0.0.0/0' except to ports 80 and 443

- Added Rego rule no_ingress_except_80_443.rego
- Added corresonding Terraform file
- Added corresponding Rego test file
- Added corresponding Rego test input file

All tests passed.